### PR TITLE
Cache world uuids instead of worlds themselves

### DIFF
--- a/src/main/java/xyz/kapurai/frostywarp/Warp.java
+++ b/src/main/java/xyz/kapurai/frostywarp/Warp.java
@@ -91,7 +91,7 @@ public class Warp implements Cloneable, ConfigurationSerializable {
     }
 
     public boolean inWorld(World world) {
-        return worldId == world.getUID();
+        return worldId.equals(world.getUID());
     }
 
     /**
@@ -110,7 +110,7 @@ public class Warp implements Cloneable, ConfigurationSerializable {
         String format = "(X=%1$d, Y=%2$d, Z=%3$d) in %4$s";
         World world = getWorld();
         String worldName = (inWorld(world)) ? world.getName() : "[unknown]";
-        return String.format(format, x, y, z, worldName);
+        return String.format(format, (int) x, (int) y, (int) z, worldName);
     }
 
     public boolean equals(Object obj) {

--- a/src/main/java/xyz/kapurai/frostywarp/Warp.java
+++ b/src/main/java/xyz/kapurai/frostywarp/Warp.java
@@ -14,34 +14,46 @@ import org.bukkit.entity.Player;
 @SerializableAs("warp")
 public class Warp implements Cloneable, ConfigurationSerializable {
 
-    private Location loc;
     private String desc;
+
+    // Store coordinates and world uuid in location
+    private double x, y, z;
+    private float pitch, yaw;
+    private UUID worldId;
 
     public Warp(Location loc, String desc) {
 
-        this.loc = loc.clone();
-        this.desc = desc;
+        this(loc.getX(), loc.getY(), loc.getZ(), loc.getPitch(), loc.getYaw(),
+             loc.getWorld().getUID(), desc);
 
     }
 
-    public void setDescription(String description) {
-        desc = description;
+    public Warp(double x, double y, double z, float pitch, float yaw,
+                UUID worldId, String desc) {
+
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.pitch = pitch;
+        this.yaw = yaw;
+        this.worldId = worldId;
+        this.desc = desc;
+
     }
 
     public String getDescription() {
         return desc;
     }
 
-
     public Map<String, Object> serialize() {
 
         Map<String, Object> map = new HashMap<>();
-        map.put("world", loc.getWorld().getUID().toString());
-        map.put("x", new Double(loc.getX()));
-        map.put("y", new Double(loc.getY()));
-        map.put("z", new Double(loc.getZ()));
-        map.put("yaw", new Float(loc.getYaw()));
-        map.put("pitch", new Float(loc.getPitch()));
+        map.put("world", worldId.toString());
+        map.put("x", new Double(x));
+        map.put("y", new Double(y));
+        map.put("z", new Double(z));
+        map.put("yaw", new Float(yaw));
+        map.put("pitch", new Float(pitch));
         if (desc != null) map.put("desc", desc);
 
         return map;
@@ -51,7 +63,7 @@ public class Warp implements Cloneable, ConfigurationSerializable {
     public static Warp deserialize(Map<String, Object> map) {
 
         // Specify default values in case of malformed object...
-        World world = Bukkit.getWorlds().get(0);
+        UUID worldId = Bukkit.getWorlds().get(0).getUID();
         double x = (Double) map.getOrDefault("x", 0.0);
         double y = (Double) map.getOrDefault("y", 0.0);
         double z = (Double) map.getOrDefault("z", 0.0);
@@ -61,30 +73,57 @@ public class Warp implements Cloneable, ConfigurationSerializable {
 
         if (map.containsKey("world")) {
             try {
-                UUID uuid = UUID.fromString((String) map.get("world"));
-                world = Bukkit.getWorld(uuid);
+                worldId = UUID.fromString((String) map.get("world"));
             } catch (IllegalArgumentException e) {}
         }
 
-        return new Warp(new Location(world, x, y, z, yaw, pitch), desc);
+        return new Warp(x, y, z, yaw, pitch, worldId, desc);
 
     }
 
-    public void teleport(Player p) {
-        p.teleport(loc);
+    public World getWorld() {
+        // Try to find the world with the given UID...
+        World world = Bukkit.getWorld(worldId);
+        if (world == null) {
+            world = Bukkit.getWorlds().get(0);
+        }
+        return world;
+    }
+
+    public boolean inWorld(World world) {
+        return worldId == world.getUID();
+    }
+
+    /**
+     * Teleport a player to this warp.
+     *
+     * @param p - the player to teleport
+     * @return location of actual teleport, or null if no teleport happened.
+     */
+    public Location teleport(Player p) {
+        Location loc = new Location(getWorld(), x, y, z, yaw, pitch);
+        if (!p.teleport(loc)) return null;
+        return loc;
     }
     
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("(X=");
-        sb.append((int) loc.getX());
-        sb.append(", Y=");
-        sb.append((int) loc.getY());
-        sb.append(", Z=");
-        sb.append((int) loc.getZ());
-        sb.append(") in ");
-        sb.append(loc.getWorld().getName());
-        return sb.toString();
+        String format = "(X=%1$d, Y=%2$d, Z=%3$d) in %4$s";
+        World world = getWorld();
+        String worldName = (inWorld(world)) ? world.getName() : "[unknown]";
+        return String.format(format, x, y, z, worldName);
+    }
+
+    public boolean equals(Object obj) {
+        if (!(obj instanceof Warp)) return false;
+        if (obj == this) return true;
+        Warp warp = (Warp) obj;
+        return warp.x == x && warp.y == y && warp.z == z
+            && warp.yaw == yaw && warp.pitch == pitch
+            && warp.desc.equals(desc);
+    }
+
+    public boolean equalsLocation(Location loc) {
+        return equals(new Warp(loc, desc));
     }
 
 }


### PR DESCRIPTION
- Closes #2.
- Don't store a bukkit Location object in Warp, instead store x, y, z, yaw, pitch, and world uuid.
- Properly handle worlds whose uuids aren't present on loading
- use String.format for creating the warp string